### PR TITLE
Add package `patch`, remove two docker volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2023-09-19
+### Added
+* Add apt package `patch` to enable installation of patches.
+
+### Removed
+* Removed docker default volumes for site configurations and labels.
+
 ## [3.0.0] - 2023-07-10
 ### Changed
 - Lift to base image `nginx:1.25.1`.
@@ -86,3 +93,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Remove basic auth.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
         git \
         gnupg2 \
         imagemagick\
+	iputils-ping \
         less \
         libgs-dev \
         locales \
@@ -39,6 +40,7 @@ RUN apt-get update && \
         lsb-release \
         msmtp \
         openrc \
+	patch \
         supervisor \
         tini \
         unzip \
@@ -108,9 +110,7 @@ RUN apt-get update && \
     # Create volume folder
     mkdir -p ${ROOT_PATH}/public/typo3temp && \
     mkdir -p ${ROOT_PATH}/public/fileadmin && \
-    mkdir -p ${ROOT_PATH}/public/uploads && \
-    mkdir -p ${ROOT_PATH}/config/sites && \
-    mkdir -p ${ROOT_PATH}/var/labels
+    mkdir -p ${ROOT_PATH}/public/uploads
 
 # Copy server configuration 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
* Add apt package `patch` to enable installation of TYPO3 patches.
* Remove docker volumes for site configs and labels because it seems best practice to persist them in the repo.